### PR TITLE
Problem fix [v2]

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -82,9 +82,9 @@ dependencies:
     - tensorflow-estimator==2.9.0
     - tensorflow-io-gcs-filesystem==0.26.0
     - termcolor==1.1.0
-    - torch==1.8.2+cu111
-    - torchaudio==0.8.2
-    - torchvision==0.9.2+cu111
+    - torch==2.1.0
+    - torchaudio==2.1.0
+    - torchvision==0.16.0
     - tqdm==4.64.0
     - typing-extensions==4.2.0
     - urllib3==1.26.9

--- a/env.py
+++ b/env.py
@@ -30,6 +30,7 @@ CONTROL_SUITE_ENVS = [
     'humanoid-walk',
     'fish-swim',
     'acrobot-swingup',
+    'quadruped-run'
 ]
 CONTROL_SUITE_ACTION_REPEATS = {
     'cartpole': 8,
@@ -41,6 +42,7 @@ CONTROL_SUITE_ACTION_REPEATS = {
     'humanoid': 2,
     'fish': 2,
     'acrobot': 4,
+    'quadruped': 2
 }
 
 

--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ parser.add_argument(
 parser.add_argument('--global-kl-beta', type=float, default=0, metavar='βg', help='Global KL weight (0 to disable)')
 parser.add_argument('--free-nats', type=float, default=3, metavar='F', help='Free nats')
 parser.add_argument('--bit-depth', type=int, default=5, metavar='B', help='Image bit depth (quantisation)')
-parser.add_argument('--model_learning-rate', type=float, default=1e-3, metavar='α', help='Learning rate')
+parser.add_argument('--model_learning-rate', type=float, default=6e-4, metavar='α', help='Learning rate')
 parser.add_argument('--actor_learning-rate', type=float, default=8e-5, metavar='α', help='Learning rate')
 parser.add_argument('--value_learning-rate', type=float, default=8e-5, metavar='α', help='Learning rate')
 parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -175,7 +175,7 @@ elif not args.test:
             D.append(observation, action, reward, done)
             observation = next_observation
             t += 1
-        metrics['steps'].append(t * args.action_repeat + (0 if len(metrics['steps']) == 0 else metrics['steps'][-1]))
+        metrics['steps'].append(int(t * args.action_repeat) + (0 if len(metrics['steps']) == 0 else metrics['steps'][-1]))
         metrics['episodes'].append(s)
 print("experience replay buffer is ready")
 
@@ -336,8 +336,8 @@ for episode in tqdm(
     losses = []
     model_modules = transition_model.modules + encoder.modules + observation_model.modules + reward_model.modules
 
-    print("training loop")
-    for s in tqdm(range(args.collect_interval)):
+    print("\n training loop")
+    for s in tqdm(range(1, args.collect_interval + 1)):
         # Draw sequence chunks {(o_t, a_t, r_t+1, terminal_t+1)} ~ D uniformly at random from the dataset (including terminal flags)
         observations, actions, rewards, nonterminals = D.sample(
             args.batch_size, args.chunk_size
@@ -535,7 +535,7 @@ for episode in tqdm(
             torch.zeros(1, args.state_size, device=args.device),
             torch.zeros(1, env.action_size, device=args.device),
         )
-        pbar = tqdm(range(args.max_episode_length // args.action_repeat))
+        pbar = tqdm(range(1, args.max_episode_length // args.action_repeat + 1))
         for t in pbar:
             # print("step",t)
             belief, posterior_state, action, next_observation, reward, done = update_belief_and_act(
@@ -560,7 +560,7 @@ for episode in tqdm(
                 break
 
         # Update and plot train reward metrics
-        metrics['steps'].append(t + metrics['steps'][-1])
+        metrics['steps'].append(int(t * args.action_repeat) + metrics['steps'][-1])
         metrics['episodes'].append(episode)
         metrics['train_rewards'].append(total_reward)
         lineplot(
@@ -651,7 +651,7 @@ for episode in tqdm(
         test_envs.close()
 
     writer.add_scalar("train_reward", metrics['train_rewards'][-1], metrics['steps'][-1])
-    writer.add_scalar("train/episode_reward", metrics['train_rewards'][-1], metrics['steps'][-1] * args.action_repeat)
+    writer.add_scalar("train/episode_reward", metrics['train_rewards'][-1], metrics['steps'][-1])
     writer.add_scalar("observation_loss", metrics['observation_loss'][0][-1], metrics['steps'][-1])
     writer.add_scalar("reward_loss", metrics['reward_loss'][0][-1], metrics['steps'][-1])
     writer.add_scalar("kl_loss", metrics['kl_loss'][0][-1], metrics['steps'][-1])

--- a/main.py
+++ b/main.py
@@ -479,7 +479,7 @@ for episode in tqdm(
             imged_reward = bottle(reward_model, (imged_beliefs, imged_prior_states))
             value_pred = bottle(value_model, (imged_beliefs, imged_prior_states))
         returns = lambda_return(
-            imged_reward, value_pred, bootstrap=value_pred[-1], discount=args.discount, lambda_=args.disclam
+            imged_reward[:-1], value_pred[:-1], bootstrap=value_pred[-1], discount=args.discount, lambda_=args.disclam
         )
         actor_loss = -torch.mean(returns)
         # Update model parameters
@@ -494,7 +494,7 @@ for episode in tqdm(
             value_prior_states = imged_prior_states.detach()
             target_return = returns.detach()
         value_dist = Normal(
-            bottle(value_model, (value_beliefs, value_prior_states)), 1
+            bottle(value_model, (value_beliefs, value_prior_states))[:-1], 1
         )  # detach the input tensor from the transition network.
         value_loss = -value_dist.log_prob(target_return).mean(dim=(0, 1))
         # Update model parameters

--- a/main.py
+++ b/main.py
@@ -681,7 +681,7 @@ for episode in tqdm(
         )
         if args.checkpoint_experience:
             torch.save(
-                D, os.path.join(results_dir, 'experience.pth')
+                D, os.path.join(results_dir, 'experience.pth'), pickle_protocol=5
             )  # Warning: will fail with MemoryError with large memory sizes
 
 

--- a/utils.py
+++ b/utils.py
@@ -74,7 +74,7 @@ def imagine_ahead(prev_state, prev_belief, policy, transition_model, planning_ho
     prev_state = flatten(prev_state)
 
     # Create lists for hidden states (cannot use single tensor as buffer because autograd won't work with inplace writes)
-    T = planning_horizon
+    T = planning_horizon + 1
     beliefs, prior_states, prior_means, prior_std_devs = (
         [torch.empty(0)] * T,
         [torch.empty(0)] * T,


### PR DESCRIPTION
There are some mistakes in the first version of the problem fix (https://github.com/yusukeurakami/dreamer-pytorch/pull/12), although I indeed got better final results.

Something to be corrected:
- The origin computation of  `reward_loss` is indeed correct and it should not be modified.

Main changes:
- [Fix 1] The computation of [`returns` in main.py](https://github.com/yusukeurakami/dreamer-pytorch/blob/b51af83694823eb07425a3f079324035bdecdb0e/main.py#L481) is modified to be the same as the 
 one at  [line 187 in dreamer.py.](https://github.com/danijar/dreamer/blob/56d4d444dfd0582b0e79dab80aebbea74c0ce40d/dreamer.py#L187)  of [Dreamer (tensorflow2 implementation)](https://github.com/danijar/dreamer).
- [Fix 2] Although both the default planning horizon of the origin paper and dreamer-pytorch are 15, this parameter is actually equal to 15-1=14 in dreamer-pytoch. This minor problem is now fixed.

The factors contributing to the issue https://github.com/yusukeurakami/dreamer-pytorch/issues/4 :
- [@letusfly85](https://github.com/letusfly85) and [@coderlemon17](https://github.com/coderlemon17) found that their training results are not as good as the testing ones of the origin paper (around 700 at 1M steps). This is reasonable because noise is added at action during training while the noise is removed when testing. Here are the training and testing results of the origin dreamer-pytoch (i.e., the version before applying my fixes) in walker-run env, where epoch 1000 stands for 1M steps.
![ori_train](https://github.com/user-attachments/assets/b627fe38-7fd0-4ea4-9636-d6eea2eb67db)
![ori_test](https://github.com/user-attachments/assets/c0b5c1ea-b969-440e-8e5f-b0470bd71967)

- Planning horizon is another factor. Here is the result of the dreamer-pytorch + Fix 2, where the testing return is around 700 at epoch 1000 (1M steps).
 
![ori_15](https://github.com/user-attachments/assets/815f796b-4c2d-4ebf-a91c-0f7bc0a3921a)

The testing result of dreamer-pytorch + Fix 1&2 is almost the same as that of dreamer-pytorch + Fix 2:
![fix_test](https://github.com/user-attachments/assets/2aa87487-73c2-4e78-91e5-479e95ccd338)

However, their value losses are different, where the value loss of dreamer-pytorch + Fix 1&2 is lower than that of dreamer-pytorch + Fix 1:
- dreamer-pytorch + Fix 2:
![ori_val](https://github.com/user-attachments/assets/f0bfa5ea-d360-4645-943a-386c5c1f8fc6)
- dreamer-pytorch +  Fix 1&2:
![fix_val](https://github.com/user-attachments/assets/edd294f3-a68d-4c3d-ac35-92328798014c)
